### PR TITLE
Fix #5, Default to the current context's namespace

### DIFF
--- a/lib/interactive/retrieve.js
+++ b/lib/interactive/retrieve.js
@@ -264,9 +264,10 @@ const chooseNextActionWithGivenSecret = (chosenSecret) => {
 };
 
 const beginWithNamespace = ({
-  namespace = 'default',
+  namespace,
 }) => {
-  const kubectlOutput = shell.exec(`kubectl get secrets -n ${namespace} -o json`, { silent: true });
+  const options = namespace ? `-n ${namespace}` : ''
+  const kubectlOutput = shell.exec(`kubectl get secrets ${options} -o json`, { silent: true });
   const secrets = processsecret.processSecrets(kubectlOutput);
   if (secrets.result === 'success') {
     inq.prompt([


### PR DESCRIPTION
### Purpose
Fixes #5

### Notes
If a user does not specify the namespace option, use the namespace set in the user's current context. This will provide a more natural behavior for kubectl users.