### PR TITLE
Accept secret name for get command

### DIFF
--- a/lib/interactive/retrieve.js
+++ b/lib/interactive/retrieve.js
@@ -297,7 +297,11 @@ const beginWithNamespace = async ({
     selectedSecretName = secretListChoice.secretName;
   }
 
-  if (selectedSecretName) {
+  if (!(selectedSecretName in secrets.secrets)) {
+    throw new Error(`Secret "${selectedSecretName}" not found in namespace "${selectedNamespace}"`)
+  }
+
+  if (selectedSecretName ) {
     chooseNextActionWithGivenSecret(secrets.secrets[selectedSecretName]);
   }
 };

--- a/lib/interactive/retrieve.js
+++ b/lib/interactive/retrieve.js
@@ -8,6 +8,7 @@ const processsecret = require('../processsecret');
 const editSecrect = require('../editsecret');
 const addKey = require('../addkey');
 const deleteKey = require('../deletekey');
+const { getCurrentContextNamespace } = require('../kube');
 
 const beginDeletingKey = (chosenSecret) => {
   inq.prompt([
@@ -263,14 +264,28 @@ const chooseNextActionWithGivenSecret = (chosenSecret) => {
   });
 };
 
-const beginWithNamespace = ({
+const beginWithNamespace = async ({
   namespace,
+  secretName,
 }) => {
+  let selectedNamespace = namespace
+  let selectedSecretName = secretName
+
+  if (!selectedNamespace) {
+    selectedNamespace = getCurrentContextNamespace()
+  }
+  console.log(`Namespace: ${selectedNamespace}`);
+
   const options = namespace ? `-n ${namespace}` : ''
   const kubectlOutput = shell.exec(`kubectl get secrets ${options} -o json`, { silent: true });
   const secrets = processsecret.processSecrets(kubectlOutput);
-  if (secrets.result === 'success') {
-    inq.prompt([
+
+  if (secrets.result !== 'success') {
+    return;
+  }
+
+  if (!selectedSecretName) {
+    const secretListChoice = await inq.prompt([
       {
         type: 'rawlist',
         name: 'secretName',
@@ -278,9 +293,12 @@ const beginWithNamespace = ({
         message: 'Choose a secret to work with:',
         pageSize: 200,
       },
-    ]).then((secretListChoice) => {
-      chooseNextActionWithGivenSecret(secrets.secrets[secretListChoice.secretName]);
-    });
+    ]);
+    selectedSecretName = secretListChoice.secretName;
+  }
+
+  if (selectedSecretName) {
+    chooseNextActionWithGivenSecret(secrets.secrets[selectedSecretName]);
   }
 };
 

--- a/lib/interactive/retrieve.js
+++ b/lib/interactive/retrieve.js
@@ -268,15 +268,15 @@ const beginWithNamespace = async ({
   namespace,
   secretName,
 }) => {
-  let selectedNamespace = namespace
-  let selectedSecretName = secretName
+  let selectedNamespace = namespace;
+  let selectedSecretName = secretName;
 
   if (!selectedNamespace) {
-    selectedNamespace = getCurrentContextNamespace()
+    selectedNamespace = getCurrentContextNamespace() || 'default';
   }
   console.log(`Namespace: ${selectedNamespace}`);
 
-  const options = namespace ? `-n ${namespace}` : ''
+  const options = namespace ? `-n ${namespace}` : '';
   const kubectlOutput = shell.exec(`kubectl get secrets ${options} -o json`, { silent: true });
   const secrets = processsecret.processSecrets(kubectlOutput);
 
@@ -298,10 +298,10 @@ const beginWithNamespace = async ({
   }
 
   if (!(selectedSecretName in secrets.secrets)) {
-    throw new Error(`Secret "${selectedSecretName}" not found in namespace "${selectedNamespace}"`)
+    throw new Error(`Secret "${selectedSecretName}" not found in namespace "${selectedNamespace}"`);
   }
 
-  if (selectedSecretName ) {
+  if (selectedSecretName) {
     chooseNextActionWithGivenSecret(secrets.secrets[selectedSecretName]);
   }
 };

--- a/lib/interactive/retrieve.js
+++ b/lib/interactive/retrieve.js
@@ -264,9 +264,10 @@ const chooseNextActionWithGivenSecret = (chosenSecret) => {
 };
 
 const beginWithNamespace = ({
-  namespace = 'default',
+  namespace,
 }) => {
-  const kubectlOutput = shell.exec(`kubectl get secrets -n ${namespace} -o json`, { silent: true });
+  const options = namespace ? `-n ${namespace}` : ''
+  const kubectlOutput = shell.exec(`kubectl get secrets ${options} -o json`, { silent: true });
   const secrets = processsecret.processSecrets(kubectlOutput);
   if (secrets.result === 'success') {
     inq.prompt([

--- a/lib/kube.js
+++ b/lib/kube.js
@@ -3,6 +3,9 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 const processSecret = require('./processsecret');
 
+const getCurrentContextNamespace = () =>
+  shell.exec('kubectl config view --minify --output \'jsonpath={..namespace}\'', { silent: true });
+
 const getSingleSecret = ({
   namespace,
   name,
@@ -49,6 +52,7 @@ ${secretInYamlForm}`);
 };
 
 module.exports = {
+  getCurrentContextNamespace,
   getSingleSecret,
   applySecret,
   convertSecretToYaml,

--- a/lib/kube.js
+++ b/lib/kube.js
@@ -3,8 +3,7 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 const processSecret = require('./processsecret');
 
-const getCurrentContextNamespace = () =>
-  shell.exec('kubectl config view --minify --output \'jsonpath={..namespace}\'', { silent: true });
+const getCurrentContextNamespace = () => shell.exec('kubectl config view --minify --output \'jsonpath={..namespace}\'', { silent: true }).stdout;
 
 const getSingleSecret = ({
   namespace,

--- a/scripts/kubesecret-get.js
+++ b/scripts/kubesecret-get.js
@@ -6,8 +6,10 @@ program
   .option('-n --namespace <namespace>', 'Namespace to filter by')
   .arguments('[secret-name]')
   .action((secretName) => {
-    console.log(`Working with namespace ${program.namespace}`);
-    interactiveget.beginWithNamespace({ namespace: program.namespace });
+    interactiveget.beginWithNamespace({
+      namespace: program.namespace,
+      secretName,
+    });
   });
 
 program.parse(process.argv);

--- a/scripts/kubesecret-get.js
+++ b/scripts/kubesecret-get.js
@@ -1,15 +1,21 @@
 const program = require('commander');
 const interactiveget = require('../lib/interactive/retrieve');
+const { red } = require('chalk');
 
 program.name('kubesecret get');
 program
   .option('-n --namespace <namespace>', 'Namespace to filter by')
   .arguments('[secret-name]')
-  .action((secretName) => {
-    interactiveget.beginWithNamespace({
-      namespace: program.namespace,
-      secretName,
-    });
+  .action(async (secretName) => {
+    try {
+      await interactiveget.beginWithNamespace({
+        namespace: program.namespace,
+        secretName,
+      });
+    } catch (err) {
+      console.log(red(`${err.message}`));
+      process.exit(1);
+    }
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
### Purpose
Builds on top of #15 to fix the ability for a user to specify the secret name to skip the interactive selection of the secret they want to edit.

```
$ kubesecret get workers-secret -n workers
Namespace: workers
Using workers-secret
? Choose next action: (Use arrow keys)
❯ View all keys
  View a specific key
  Edit secret
  Remove secret (TODO)
  Exit
```

### Notes
This argument was already part of the cli, just not implemented yet 😄 